### PR TITLE
Find templates.

### DIFF
--- a/DependencyInjection/ToinouSummernoteExtension.php
+++ b/DependencyInjection/ToinouSummernoteExtension.php
@@ -18,7 +18,7 @@ class ToinouSummernoteExtension extends Extension implements PrependExtensionInt
     /**
      * @var string
      */
-    protected $formTypeTemplate = 'ToinouSummernoteBundle:Form:summernoteField.html.twig';
+    protected $formTypeTemplate = '@ToinouSummernote/Form/summernoteField.html.twig';
 
     /**
      * {@inheritdoc}

--- a/README.md
+++ b/README.md
@@ -27,6 +27,26 @@ You have two ways to download and install the bundle:
     }
 }
 ```
+Given there is no tag yet you have to add the following to your `composer.json` file:
+```json
+    "repositories": [
+        {
+            "type": "package",
+            "package": {
+                "name": "Toinou97434/summernoteBundle",
+                "version": "master",
+                "dist": {
+                    "type": "zip",
+                    "url": "https://github.com/Toinou97434/summernoteBundle/archive/master.zip",
+                    "reference": "master"
+                },
+                "autoload": {
+                    "classmap": ["."]
+                }
+            }
+        }
+    ]
+```
 and making your composer update:
 ```command
 php composer.phar update

--- a/Twig/Extension/FormExtension.php
+++ b/Twig/Extension/FormExtension.php
@@ -32,7 +32,7 @@ class FormExtension extends \Twig_Extension implements \Twig_Extension_GlobalsIn
     public function renderJavascript($form = null)
     {
         $this->template = $this->environment->loadTemplate(
-            'ToinouSummernoteBundle:Form:summernoteJavascript.html.twig'
+            '@ToinouSummernote/Form/summernoteJavascript.html.twig'
         );
         $formOptions = array();
         foreach ($form as $child) {


### PR DESCRIPTION
hi,
i got an error using this bundle in Symfony 3.4.10

Unable to find template "ToinouSummernoteBundle:Form:summernoteJavascript.html.twig" (looked into: app/Resources/views, vendor/symfony/symfony/src/Symfony/Bridge/Twig/Resources/views/Form).

the commit fixes this.